### PR TITLE
No breaking changes proposal

### DIFF
--- a/src/NHibernate.Test/Async/BulkManipulation/NativeSQLBulkOperationsWithCache.cs
+++ b/src/NHibernate.Test/Async/BulkManipulation/NativeSQLBulkOperationsWithCache.cs
@@ -15,7 +15,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NHibernate.Cache;
 using NHibernate.Cfg;
-using NHibernate.Engine;
 using NSubstitute;
 using NUnit.Framework;
 using Environment = NHibernate.Cfg.Environment;
@@ -29,7 +28,6 @@ namespace NHibernate.Test.BulkManipulation
 		protected override string MappingsAssembly => "NHibernate.Test";
 
 		protected override IList Mappings => new[] { "BulkManipulation.Vehicle.hbm.xml" };
-
 
 		protected override void Configure(Configuration configuration)
 		{
@@ -68,11 +66,7 @@ namespace NHibernate.Test.BulkManipulation
 
 					Assert.AreEqual(0, clearCalls.Count);
 				}
-
 			}
-
-
 		}
-		
 	}
 }

--- a/src/NHibernate.Test/Async/DebugSessionFactory.cs
+++ b/src/NHibernate.Test/Async/DebugSessionFactory.cs
@@ -55,11 +55,6 @@ namespace NHibernate.Test
 			return ActualFactory.EvictAsync(persistentClass, cancellationToken);
 		}
 
-		Task ISessionFactory.EvictAsync(IEnumerable<System.Type> persistentClasses, CancellationToken cancellationToken)
-		{
-			return ActualFactory.EvictAsync(persistentClasses, cancellationToken);
-		}
-
 		Task ISessionFactory.EvictAsync(System.Type persistentClass, object id, CancellationToken cancellationToken)
 		{
 			return ActualFactory.EvictAsync(persistentClass, id, cancellationToken);
@@ -70,11 +65,6 @@ namespace NHibernate.Test
 			return ActualFactory.EvictEntityAsync(entityName, cancellationToken);
 		}
 
-		Task ISessionFactory.EvictEntityAsync(IEnumerable<string> entityNames, CancellationToken cancellationToken)
-		{
-			return ActualFactory.EvictEntityAsync(entityNames, cancellationToken);
-		}
-
 		Task ISessionFactory.EvictEntityAsync(string entityName, object id, CancellationToken cancellationToken)
 		{
 			return ActualFactory.EvictEntityAsync(entityName, id, cancellationToken);
@@ -83,11 +73,6 @@ namespace NHibernate.Test
 		Task ISessionFactory.EvictCollectionAsync(string roleName, CancellationToken cancellationToken)
 		{
 			return ActualFactory.EvictCollectionAsync(roleName, cancellationToken);
-		}
-
-		Task ISessionFactory.EvictCollectionAsync(IEnumerable<string> roleNames, CancellationToken cancellationToken)
-		{
-			return ActualFactory.EvictCollectionAsync(roleNames, cancellationToken);
 		}
 
 		Task ISessionFactory.EvictCollectionAsync(string roleName, object id, CancellationToken cancellationToken)

--- a/src/NHibernate.Test/BulkManipulation/BulkOperationCleanupActionFixture.cs
+++ b/src/NHibernate.Test/BulkManipulation/BulkOperationCleanupActionFixture.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NHibernate.Action;
 using NHibernate.Engine;
-using NHibernate.Impl;
 using NHibernate.Metadata;
 using NHibernate.Persister.Entity;
 using NSubstitute;

--- a/src/NHibernate.Test/BulkManipulation/BulkOperationCleanupActionFixture.cs
+++ b/src/NHibernate.Test/BulkManipulation/BulkOperationCleanupActionFixture.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using NHibernate.Action;
 using NHibernate.Engine;
+using NHibernate.Impl;
 using NHibernate.Metadata;
 using NHibernate.Persister.Entity;
 using NSubstitute;
@@ -40,6 +38,8 @@ namespace NHibernate.Test.BulkManipulation
 		[TestCase("TestClass", false, 1, 0, 1)]
 		[TestCase("", true, 1, 1, 1)]
 		[Test]
+		// 6.0 TODO: remove this ignore.
+		[Ignore("Must wait for the tested methods to be actually added to ISessionFactoryImplementor")]
 		public void AfterTransactionCompletionProcess_EvictsFromCache(string querySpaces, bool persisterHasCache, int expectedPropertySpaceLength, int expectedEntityEvictionCount, int expectedCollectionEvictionCount)
 		{
 			_persister.HasCache.Returns(persisterHasCache);
@@ -67,7 +67,6 @@ namespace NHibernate.Test.BulkManipulation
 			{
 				_factory.DidNotReceive().EvictCollection(Arg.Any<IEnumerable<string>>());
 			}
-
 		}
 	}
 }

--- a/src/NHibernate.Test/BulkManipulation/NativeSQLBulkOperationsWithCache.cs
+++ b/src/NHibernate.Test/BulkManipulation/NativeSQLBulkOperationsWithCache.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NHibernate.Cache;
 using NHibernate.Cfg;
-using NHibernate.Engine;
 using NSubstitute;
 using NUnit.Framework;
 using Environment = NHibernate.Cfg.Environment;
@@ -18,7 +17,6 @@ namespace NHibernate.Test.BulkManipulation
 		protected override string MappingsAssembly => "NHibernate.Test";
 
 		protected override IList Mappings => new[] { "BulkManipulation.Vehicle.hbm.xml" };
-
 
 		protected override void Configure(Configuration configuration)
 		{
@@ -57,12 +55,8 @@ namespace NHibernate.Test.BulkManipulation
 
 					Assert.AreEqual(0, clearCalls.Count);
 				}
-
 			}
-
-
 		}
-		
 	}
 
 	public class SubstituteCacheProvider : ICacheProvider

--- a/src/NHibernate.Test/DebugSessionFactory.cs
+++ b/src/NHibernate.Test/DebugSessionFactory.cs
@@ -221,11 +221,6 @@ namespace NHibernate.Test
 			ActualFactory.Evict(persistentClass);
 		}
 
-		void ISessionFactory.Evict(IEnumerable<System.Type> persistentClasses)
-		{
-			ActualFactory.Evict(persistentClasses);
-		}
-
 		void ISessionFactory.Evict(System.Type persistentClass, object id)
 		{
 			ActualFactory.Evict(persistentClass, id);
@@ -236,11 +231,6 @@ namespace NHibernate.Test
 			ActualFactory.EvictEntity(entityName);
 		}
 
-		void ISessionFactory.EvictEntity(IEnumerable<string> entityNames)
-		{
-			ActualFactory.EvictEntity(entityNames);
-		}
-
 		void ISessionFactory.EvictEntity(string entityName, object id)
 		{
 			ActualFactory.EvictEntity(entityName, id);
@@ -249,11 +239,6 @@ namespace NHibernate.Test
 		void ISessionFactory.EvictCollection(string roleName)
 		{
 			ActualFactory.EvictCollection(roleName);
-		}
-
-		void ISessionFactory.EvictCollection(IEnumerable<string> roleNames)
-		{
-			ActualFactory.EvictCollection(roleNames);
 		}
 
 		void ISessionFactory.EvictCollection(string roleName, object id)

--- a/src/NHibernate/Action/BulkOperationCleanupAction.cs
+++ b/src/NHibernate/Action/BulkOperationCleanupAction.cs
@@ -144,7 +144,5 @@ namespace NHibernate.Action
 		}
 
 		#endregion
-
-		
 	}
 }

--- a/src/NHibernate/Async/Action/BulkOperationCleanupAction.cs
+++ b/src/NHibernate/Async/Action/BulkOperationCleanupAction.cs
@@ -60,7 +60,5 @@ namespace NHibernate.Action
 		}
 
 		#endregion
-
-		
 	}
 }

--- a/src/NHibernate/Async/ISessionFactory.cs
+++ b/src/NHibernate/Async/ISessionFactory.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using NHibernate.Connection;
 using NHibernate.Engine;
+using NHibernate.Impl;
 using NHibernate.Metadata;
 using NHibernate.Stat;
 
@@ -21,6 +22,87 @@ namespace NHibernate
 {
 	using System.Threading.Tasks;
 	using System.Threading;
+	public static partial class SessionFactoryExtension
+	{
+		/// <summary>
+		/// Evict all entries from the process-level cache. This method occurs outside
+		/// of any transaction; it performs an immediate "hard" remove, so does not respect
+		/// any transaction isolation semantics of the usage strategy. Use with care.
+		/// </summary>
+		/// <param name="factory">The session factory.</param>
+		/// <param name="persistentClasses">The classes of the entities to evict.</param>
+		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
+		public static async Task EvictAsync(this ISessionFactory factory, IEnumerable<System.Type> persistentClasses, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (factory is SessionFactoryImpl sfi)
+			{
+				await (sfi.EvictAsync(persistentClasses, cancellationToken)).ConfigureAwait(false);
+			}
+			else
+			{
+				if (persistentClasses == null)
+					throw new ArgumentNullException(nameof(persistentClasses));
+				foreach (var @class in persistentClasses)
+				{
+					await (factory.EvictAsync(@class, cancellationToken)).ConfigureAwait(false);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Evict all entries from the second-level cache. This method occurs outside
+		/// of any transaction; it performs an immediate "hard" remove, so does not respect
+		/// any transaction isolation semantics of the usage strategy. Use with care.
+		/// </summary>
+		/// <param name="factory">The session factory.</param>
+		/// <param name="entityNames">The names of the entities to evict.</param>
+		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
+		public static async Task EvictEntityAsync(this ISessionFactory factory, IEnumerable<string> entityNames, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (factory is SessionFactoryImpl sfi)
+			{
+				await (sfi.EvictEntityAsync(entityNames, cancellationToken)).ConfigureAwait(false);
+			}
+			else
+			{
+				if (entityNames == null)
+					throw new ArgumentNullException(nameof(entityNames));
+				foreach (var name in entityNames)
+				{
+					await (factory.EvictEntityAsync(name, cancellationToken)).ConfigureAwait(false);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Evict all entries from the process-level cache. This method occurs outside
+		/// of any transaction; it performs an immediate "hard" remove, so does not respect
+		/// any transaction isolation semantics of the usage strategy. Use with care.
+		/// </summary>
+		/// <param name="factory">The session factory.</param>
+		/// <param name="roleNames">The names of the collections to evict.</param>
+		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
+		public static async Task EvictCollectionAsync(this ISessionFactory factory, IEnumerable<string> roleNames, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (factory is SessionFactoryImpl sfi)
+			{
+				await (sfi.EvictCollectionAsync(roleNames, cancellationToken)).ConfigureAwait(false);
+			}
+			else
+			{
+				if (roleNames == null)
+					throw new ArgumentNullException(nameof(roleNames));
+				foreach (var role in roleNames)
+				{
+					await (factory.EvictCollectionAsync(role, cancellationToken)).ConfigureAwait(false);
+				}
+			}
+		}
+	}
+
 	public partial interface ISessionFactory : IDisposable
 	{
 
@@ -43,15 +125,6 @@ namespace NHibernate
 		Task EvictAsync(System.Type persistentClass, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
-		/// Evict all entries from the process-level cache.  This method occurs outside
-		/// of any transaction; it performs an immediate "hard" remove, so does not respect
-		/// any transaction isolation semantics of the usage strategy.  Use with care.
-		/// </summary>
-		/// <param name="persistentClasses"></param>
-		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
-		Task EvictAsync(IEnumerable<System.Type> persistentClasses, CancellationToken cancellationToken = default(CancellationToken));
-
-		/// <summary>
 		/// Evict an entry from the process-level cache.  This method occurs outside
 		/// of any transaction; it performs an immediate "hard" remove, so does not respect
 		/// any transaction isolation semantics of the usage strategy.  Use with care.
@@ -69,13 +142,6 @@ namespace NHibernate
 		Task EvictEntityAsync(string entityName, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary> 
-		/// Evict all entries from the second-level cache. This method occurs outside
-		/// of any transaction; it performs an immediate "hard" remove, so does not respect
-		/// any transaction isolation semantics of the usage strategy. Use with care.
-		/// </summary>
-		Task EvictEntityAsync(IEnumerable<string> entityNames, CancellationToken cancellationToken = default(CancellationToken));
-
-		/// <summary> 
 		/// Evict an entry from the second-level  cache. This method occurs outside
 		/// of any transaction; it performs an immediate "hard" remove, so does not respect
 		/// any transaction isolation semantics of the usage strategy. Use with care.
@@ -90,15 +156,6 @@ namespace NHibernate
 		/// <param name="roleName"></param>
 		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
 		Task EvictCollectionAsync(string roleName, CancellationToken cancellationToken = default(CancellationToken));
-
-		/// <summary>
-		/// Evict all entries from the process-level cache.  This method occurs outside
-		/// of any transaction; it performs an immediate "hard" remove, so does not respect
-		/// any transaction isolation semantics of the usage strategy.  Use with care.
-		/// </summary>
-		/// <param name="roleNames"></param>
-		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
-		Task EvictCollectionAsync(IEnumerable<string> roleNames, CancellationToken cancellationToken = default(CancellationToken));
 
 		/// <summary>
 		/// Evict an entry from the process-level cache.  This method occurs outside

--- a/src/NHibernate/Async/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Async/Impl/SessionFactoryImpl.cs
@@ -165,7 +165,7 @@ namespace NHibernate.Impl
 			}
 		}
 
-		public Task EvictAsync(IEnumerable<System.Type> persistentClasses, CancellationToken cancellationToken = default(CancellationToken))
+		public Task EvictAsync(IEnumerable<System.Type> persistentClasses, CancellationToken cancellationToken)
 		{
 			if (persistentClasses == null)
 				throw new ArgumentNullException(nameof(persistentClasses));
@@ -208,7 +208,7 @@ namespace NHibernate.Impl
 			}
 		}
 
-		public Task EvictEntityAsync(IEnumerable<string> entityNames, CancellationToken cancellationToken = default(CancellationToken))
+		public Task EvictEntityAsync(IEnumerable<string> entityNames, CancellationToken cancellationToken)
 		{
 			if (entityNames == null)
 				throw new ArgumentNullException(nameof(entityNames));
@@ -309,7 +309,7 @@ namespace NHibernate.Impl
 			}
 		}
 
-		public Task EvictCollectionAsync(IEnumerable<string> roleNames, CancellationToken cancellationToken = default(CancellationToken))
+		public Task EvictCollectionAsync(IEnumerable<string> roleNames, CancellationToken cancellationToken)
 		{
 			if (roleNames == null)
 				throw new ArgumentNullException(nameof(roleNames));

--- a/src/NHibernate/Async/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Async/Impl/SessionFactoryImpl.cs
@@ -224,10 +224,8 @@ namespace NHibernate.Impl
 				{
 					if (log.IsDebugEnabled())
 					{
-						foreach (var p in cacheGroup)
-						{
-							log.Debug("evicting second-level cache: " + p.EntityName);
-						}
+						log.Debug("evicting second-level cache for: {0}",
+					          string.Join(", ", cacheGroup.Select(p => p.EntityName)));
 					}
 					await (cacheGroup.Key.ClearAsync(cancellationToken)).ConfigureAwait(false);
 				}
@@ -325,13 +323,10 @@ namespace NHibernate.Impl
 
 				foreach (var cacheGroup in roleNames.Select(GetCollectionPersister).Where(x => x.HasCache).GroupBy(x => x.Cache))
 				{
-				
 					if (log.IsDebugEnabled())
 					{
-						foreach (var p in cacheGroup)
-						{
-							log.Debug("evicting second-level cache: " + p.Role);
-						}
+						log.Debug("evicting second-level cache for: {0}",
+					          string.Join(", ", cacheGroup.Select(p => p.Role)));
 					}
 					await (cacheGroup.Key.ClearAsync(cancellationToken)).ConfigureAwait(false);
 				}

--- a/src/NHibernate/Async/Impl/SqlQueryImpl.cs
+++ b/src/NHibernate/Async/Impl/SqlQueryImpl.cs
@@ -121,6 +121,5 @@ namespace NHibernate.Impl
 				return Task.FromException<IEnumerable<ITranslator>>(ex);
 			}
 		}
-		
 	}
 }

--- a/src/NHibernate/Async/Impl/SqlQueryImpl.cs
+++ b/src/NHibernate/Async/Impl/SqlQueryImpl.cs
@@ -21,7 +21,7 @@ namespace NHibernate.Impl
 {
 	using System.Threading.Tasks;
 	using System.Threading;
-	public partial class SqlQueryImpl : AbstractQueryImpl, ISQLQuery
+	public partial class SqlQueryImpl : AbstractQueryImpl, ISQLQuery, ISynchronizableSQLQuery
 	{
 
 		public override async Task<IList> ListAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/NHibernate/ISQLQuery.cs
+++ b/src/NHibernate/ISQLQuery.cs
@@ -1,8 +1,70 @@
+using System;
+using System.Collections.Generic;
 using NHibernate.Type;
 
 namespace NHibernate
 {
-	public interface ISQLQuery : IQuery, ISynchronizableQuery<ISQLQuery>
+	// 6.0 TODO: remove after having done ISynchronizableSQLQuery todo
+	public static class SQLQueryExtension
+	{
+		/// <summary>
+		/// Adds a query space for auto-flush synchronization and second level cache invalidation.
+		/// </summary>
+		/// <param name="sqlQuery">The query.</param>
+		/// <param name="querySpace">The query space.</param>
+		/// <returns>The query.</returns>
+		public static ISQLQuery AddSynchronizedQuerySpace(this ISQLQuery sqlQuery, string querySpace)
+		{
+			if (!(sqlQuery is ISynchronizableSQLQuery ssq))
+				throw new NotSupportedException($"The query must implement {nameof(ISynchronizableSQLQuery)}");
+			return ssq.AddSynchronizedQuerySpace(querySpace);
+		}
+
+		/// <summary>
+		/// Adds an entity name for auto-flush synchronization and second level cache invalidation.
+		/// </summary>
+		/// <param name="sqlQuery">The query.</param>
+		/// <param name="entityName">The entity name.</param>
+		/// <returns>The query.</returns>
+		public static ISQLQuery AddSynchronizedEntityName(this ISQLQuery sqlQuery, string entityName)
+		{
+			if (!(sqlQuery is ISynchronizableSQLQuery ssq))
+				throw new NotSupportedException($"The query must implement {nameof(ISynchronizableSQLQuery)}");
+			return ssq.AddSynchronizedEntityName(entityName);
+		}
+
+		/// <summary>
+		/// Adds an entity type for auto-flush synchronization and second level cache invalidation.
+		/// </summary>
+		/// <param name="sqlQuery">The query.</param>
+		/// <param name="entityType">The entity type.</param>
+		/// <returns>The query.</returns>
+		public static ISQLQuery AddSynchronizedEntityClass(this ISQLQuery sqlQuery, System.Type entityType)
+		{
+			if (!(sqlQuery is ISynchronizableSQLQuery ssq))
+				throw new NotSupportedException($"The query must implement {nameof(ISynchronizableSQLQuery)}");
+			return ssq.AddSynchronizedEntityClass(entityType);
+		}
+
+		/// <summary>
+		/// Returns the synchronized query spaces added to the query.
+		/// </summary>
+		/// <param name="sqlQuery">The query.</param>
+		/// <returns>The synchronized query spaces.</returns>
+		public static IReadOnlyCollection<string> GetSynchronizedQuerySpaces(this ISQLQuery sqlQuery)
+		{
+			if (!(sqlQuery is ISynchronizableSQLQuery ssq))
+				throw new NotSupportedException($"The query must implement {nameof(ISynchronizableSQLQuery)}");
+			return ssq.GetSynchronizedQuerySpaces();
+		}
+	}
+
+	// 6.0 TODO: obsolete ISynchronizableSQLQuery and have ISQLQuery directly extending ISynchronizableQuery<ISQLQuery>
+	public interface ISynchronizableSQLQuery : ISQLQuery, ISynchronizableQuery<ISynchronizableSQLQuery>
+	{
+	}
+
+	public interface ISQLQuery : IQuery
 	{
 		/// <summary>
 		/// Declare a "root" entity, without specifying an alias

--- a/src/NHibernate/ISessionFactory.cs
+++ b/src/NHibernate/ISessionFactory.cs
@@ -4,11 +4,88 @@ using System.Collections.Generic;
 using System.Data.Common;
 using NHibernate.Connection;
 using NHibernate.Engine;
+using NHibernate.Impl;
 using NHibernate.Metadata;
 using NHibernate.Stat;
 
 namespace NHibernate
 {
+	// 6.0 TODO: move below methods directly in ISessionFactory then remove SessionFactoryExtension
+	public static partial class SessionFactoryExtension
+	{
+		/// <summary>
+		/// Evict all entries from the process-level cache. This method occurs outside
+		/// of any transaction; it performs an immediate "hard" remove, so does not respect
+		/// any transaction isolation semantics of the usage strategy. Use with care.
+		/// </summary>
+		/// <param name="factory">The session factory.</param>
+		/// <param name="persistentClasses">The classes of the entities to evict.</param>
+		public static void Evict(this ISessionFactory factory, IEnumerable<System.Type> persistentClasses)
+		{
+			if (factory is SessionFactoryImpl sfi)
+			{
+				sfi.Evict(persistentClasses);
+			}
+			else
+			{
+				if (persistentClasses == null)
+					throw new ArgumentNullException(nameof(persistentClasses));
+				foreach (var @class in persistentClasses)
+				{
+					factory.Evict(@class);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Evict all entries from the second-level cache. This method occurs outside
+		/// of any transaction; it performs an immediate "hard" remove, so does not respect
+		/// any transaction isolation semantics of the usage strategy. Use with care.
+		/// </summary>
+		/// <param name="factory">The session factory.</param>
+		/// <param name="entityNames">The names of the entities to evict.</param>
+		public static void EvictEntity(this ISessionFactory factory, IEnumerable<string> entityNames)
+		{
+			if (factory is SessionFactoryImpl sfi)
+			{
+				sfi.EvictEntity(entityNames);
+			}
+			else
+			{
+				if (entityNames == null)
+					throw new ArgumentNullException(nameof(entityNames));
+				foreach (var name in entityNames)
+				{
+					factory.EvictEntity(name);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Evict all entries from the process-level cache. This method occurs outside
+		/// of any transaction; it performs an immediate "hard" remove, so does not respect
+		/// any transaction isolation semantics of the usage strategy. Use with care.
+		/// </summary>
+		/// <param name="factory">The session factory.</param>
+		/// <param name="roleNames">The names of the collections to evict.</param>
+		public static void EvictCollection(this ISessionFactory factory, IEnumerable<string> roleNames)
+		{
+			if (factory is SessionFactoryImpl sfi)
+			{
+				sfi.EvictCollection(roleNames);
+			}
+			else
+			{
+				if (roleNames == null)
+					throw new ArgumentNullException(nameof(roleNames));
+				foreach (var role in roleNames)
+				{
+					factory.EvictCollection(role);
+				}
+			}
+		}
+	}
+
 	/// <summary>
 	/// Creates <c>ISession</c>s.
 	/// </summary>
@@ -148,14 +225,6 @@ namespace NHibernate
 		void Evict(System.Type persistentClass);
 
 		/// <summary>
-		/// Evict all entries from the process-level cache.  This method occurs outside
-		/// of any transaction; it performs an immediate "hard" remove, so does not respect
-		/// any transaction isolation semantics of the usage strategy.  Use with care.
-		/// </summary>
-		/// <param name="persistentClasses"></param>
-		void Evict(IEnumerable<System.Type> persistentClasses);
-
-		/// <summary>
 		/// Evict an entry from the process-level cache.  This method occurs outside
 		/// of any transaction; it performs an immediate "hard" remove, so does not respect
 		/// any transaction isolation semantics of the usage strategy.  Use with care.
@@ -172,13 +241,6 @@ namespace NHibernate
 		void EvictEntity(string entityName);
 
 		/// <summary> 
-		/// Evict all entries from the second-level cache. This method occurs outside
-		/// of any transaction; it performs an immediate "hard" remove, so does not respect
-		/// any transaction isolation semantics of the usage strategy. Use with care.
-		/// </summary>
-		void EvictEntity(IEnumerable<string> entityNames);
-
-		/// <summary> 
 		/// Evict an entry from the second-level  cache. This method occurs outside
 		/// of any transaction; it performs an immediate "hard" remove, so does not respect
 		/// any transaction isolation semantics of the usage strategy. Use with care.
@@ -192,14 +254,6 @@ namespace NHibernate
 		/// </summary>
 		/// <param name="roleName"></param>
 		void EvictCollection(string roleName);
-
-		/// <summary>
-		/// Evict all entries from the process-level cache.  This method occurs outside
-		/// of any transaction; it performs an immediate "hard" remove, so does not respect
-		/// any transaction isolation semantics of the usage strategy.  Use with care.
-		/// </summary>
-		/// <param name="roleNames"></param>
-		void EvictCollection(IEnumerable<string> roleNames);
 
 		/// <summary>
 		/// Evict an entry from the process-level cache.  This method occurs outside

--- a/src/NHibernate/ISynchronizableQuery.cs
+++ b/src/NHibernate/ISynchronizableQuery.cs
@@ -7,28 +7,28 @@ namespace NHibernate
 		/// <summary>
 		/// Adds a query space for auto-flush synchronization and second level cache invalidation.
 		/// </summary>
-		/// <param name="querySpace"></param>
-		/// <returns></returns>
+		/// <param name="querySpace">The query space.</param>
+		/// <returns>The query.</returns>
 		T AddSynchronizedQuerySpace(string querySpace);
 
 		/// <summary>
 		/// Adds an entity name for auto-flush synchronization and second level cache invalidation.
 		/// </summary>
-		/// <param name="entityName"></param>
-		/// <returns></returns>
+		/// <param name="entityName">The entity name.</param>
+		/// <returns>The query.</returns>
 		T AddSynchronizedEntityName(string entityName);
 
 		/// <summary>
 		/// Adds an entity type for auto-flush synchronization and second level cache invalidation.
 		/// </summary>
-		/// <param name="entityType"></param>
-		/// <returns></returns>
+		/// <param name="entityType">The entity type.</param>
+		/// <returns>The query.</returns>
 		T AddSynchronizedEntityClass(System.Type entityType);
 
 		/// <summary>
-		/// 
+		/// Returns the synchronized query spaces added to the query.
 		/// </summary>
-		/// <returns></returns>
+		/// <returns>The synchronized query spaces.</returns>
 		IReadOnlyCollection<string> GetSynchronizedQuerySpaces();
 	}
 }

--- a/src/NHibernate/Impl/AbstractQueryImpl.cs
+++ b/src/NHibernate/Impl/AbstractQueryImpl.cs
@@ -42,7 +42,7 @@ namespace NHibernate.Impl
 		private CacheMode? cacheMode;
 		private CacheMode? sessionCacheMode;
 		private string comment;
-		
+
 		protected AbstractQueryImpl(string queryString, FlushMode flushMode, ISessionImplementor session,
 			ParameterMetadata parameterMetadata)
 		{

--- a/src/NHibernate/Impl/SessionFactoryImpl.cs
+++ b/src/NHibernate/Impl/SessionFactoryImpl.cs
@@ -930,10 +930,8 @@ namespace NHibernate.Impl
 			{
 				if (log.IsDebugEnabled())
 				{
-					foreach (var p in cacheGroup)
-					{
-						log.Debug("evicting second-level cache: " + p.EntityName);
-					}
+					log.Debug("evicting second-level cache for: {0}",
+					          string.Join(", ", cacheGroup.Select(p => p.EntityName)));
 				}
 				cacheGroup.Key.Clear();
 			}
@@ -1001,13 +999,10 @@ namespace NHibernate.Impl
 
 			foreach (var cacheGroup in roleNames.Select(GetCollectionPersister).Where(x => x.HasCache).GroupBy(x => x.Cache))
 			{
-			
 				if (log.IsDebugEnabled())
 				{
-					foreach (var p in cacheGroup)
-					{
-						log.Debug("evicting second-level cache: " + p.Role);
-					}
+					log.Debug("evicting second-level cache for: {0}",
+					          string.Join(", ", cacheGroup.Select(p => p.Role)));
 				}
 				cacheGroup.Key.Clear();
 			}

--- a/src/NHibernate/Impl/SqlQueryImpl.cs
+++ b/src/NHibernate/Impl/SqlQueryImpl.cs
@@ -22,7 +22,7 @@ namespace NHibernate.Impl
 	/// &lt;/sql-query-name&gt;
 	/// </code>
 	/// </example>
-	public partial class SqlQueryImpl : AbstractQueryImpl, ISQLQuery
+	public partial class SqlQueryImpl : AbstractQueryImpl, ISQLQuery, ISynchronizableSQLQuery
 	{
 		private readonly IList<INativeSQLQueryReturn> queryReturns;
 		private readonly ICollection<string> querySpaces;
@@ -327,13 +327,13 @@ namespace NHibernate.Impl
 			yield return new SqlTranslator(sqlQuery, sessionImplementor.Factory);
 		}
 
-		public ISQLQuery AddSynchronizedQuerySpace(string querySpace)
+		public ISynchronizableSQLQuery AddSynchronizedQuerySpace(string querySpace)
 		{
 			addedQuerySpaces.Add(querySpace);
 			return this;
 		}
 
-		public ISQLQuery AddSynchronizedEntityName(string entityName)
+		public ISynchronizableSQLQuery AddSynchronizedEntityName(string entityName)
 		{
 			var persister = session.Factory.GetEntityPersister(entityName);
 			foreach (var querySpace in persister.QuerySpaces)
@@ -343,7 +343,7 @@ namespace NHibernate.Impl
 			return this;
 		}
 
-		public ISQLQuery AddSynchronizedEntityClass(System.Type entityType)
+		public ISynchronizableSQLQuery AddSynchronizedEntityClass(System.Type entityType)
 		{
 			var persister = session.Factory.GetEntityPersister(entityType.FullName);
 			foreach (var querySpace in persister.QuerySpaces)

--- a/src/NHibernate/Impl/SqlQueryImpl.cs
+++ b/src/NHibernate/Impl/SqlQueryImpl.cs
@@ -28,8 +28,7 @@ namespace NHibernate.Impl
 		private readonly ICollection<string> querySpaces;
 		private readonly bool callable;
 		private bool autoDiscoverTypes;
-		private readonly Lazy<HashSet<string>> addedQuerySpaces = new Lazy<HashSet<string>>(() => new HashSet<string>());
-
+		private readonly HashSet<string> addedQuerySpaces = new HashSet<string>();
 
 		/// <summary> Constructs a SQLQueryImpl given a sql query defined in the mappings. </summary>
 		/// <param name="queryDef">The representation of the defined sql-query. </param>
@@ -172,7 +171,7 @@ namespace NHibernate.Impl
 
 		public NativeSQLQuerySpecification GenerateQuerySpecification(IDictionary<string, TypedValue> parameters)
 		{
-			var allQuerySpaces=new List<string>(GetSynchronizedQuerySpaces());
+			var allQuerySpaces = new List<string>(GetSynchronizedQuerySpaces());
 			if (querySpaces != null)
 			{
 				allQuerySpaces.AddRange(querySpaces);
@@ -330,7 +329,7 @@ namespace NHibernate.Impl
 
 		public ISQLQuery AddSynchronizedQuerySpace(string querySpace)
 		{
-			addedQuerySpaces.Value.Add(querySpace);
+			addedQuerySpaces.Add(querySpace);
 			return this;
 		}
 
@@ -339,7 +338,7 @@ namespace NHibernate.Impl
 			var persister = session.Factory.GetEntityPersister(entityName);
 			foreach (var querySpace in persister.QuerySpaces)
 			{
-				addedQuerySpaces.Value.Add(querySpace);
+				addedQuerySpaces.Add(querySpace);
 			}
 			return this;
 		}
@@ -349,15 +348,14 @@ namespace NHibernate.Impl
 			var persister = session.Factory.GetEntityPersister(entityType.FullName);
 			foreach (var querySpace in persister.QuerySpaces)
 			{
-				addedQuerySpaces.Value.Add(querySpace);
+				addedQuerySpaces.Add(querySpace);
 			}
 			return this;
 		}
 
 		public IReadOnlyCollection<string> GetSynchronizedQuerySpaces()
 		{
-			return addedQuerySpaces.IsValueCreated ? addedQuerySpaces.Value : new HashSet<string>();
+			return addedQuerySpaces;
 		}
-		
 	}
 }


### PR DESCRIPTION
Adding members to an interface and adding an ancestor to an interface are breaking changes which would mandate a 6.0 version.

If we want #1381 (PR #1392) to be in 5.2, we have to avoid them.

This PR aims at that.